### PR TITLE
Update base VM template (packer-debian-12.11.0-8c25eadf-6181-4127-ab26-ca9f89e31a87)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,14 +3,14 @@
     {
       "name": "debian-12",
       "builder_type": "proxmox-iso",
-      "build_time": 1747660021,
+      "build_time": 1748166602,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "d188debe-ab0e-459d-6979-7c8d1b71a89f",
+      "packer_run_uuid": "949620a7-8194-36dd-b104-13ab92884904",
       "custom_data": {
-        "vm_name": "packer-debian-12.11.0-8755036c-f58e-4cbd-863c-8eff1188f085"
+        "vm_name": "packer-debian-12.11.0-8c25eadf-6181-4127-ab26-ca9f89e31a87"
       }
     }
   ],
-  "last_run_uuid": "d188debe-ab0e-459d-6979-7c8d1b71a89f"
+  "last_run_uuid": "949620a7-8194-36dd-b104-13ab92884904"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.