### PR TITLE
Update base VM template (packer-debian-12.11.0-20250525125637)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,14 +3,15 @@
     {
       "name": "debian-12",
       "builder_type": "proxmox-iso",
-      "build_time": 1747660021,
+      "build_time": 1748178465,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "d188debe-ab0e-459d-6979-7c8d1b71a89f",
+      "packer_run_uuid": "8c963411-f62b-957f-aa98-d44e3b164764",
       "custom_data": {
-        "vm_name": "packer-debian-12.11.0-8755036c-f58e-4cbd-863c-8eff1188f085"
+        "git_tag": "v12.11.0.20250525125637",
+        "vm_name": "packer-debian-12.11.0-20250525125637"
       }
     }
   ],
-  "last_run_uuid": "d188debe-ab0e-459d-6979-7c8d1b71a89f"
+  "last_run_uuid": "8c963411-f62b-957f-aa98-d44e3b164764"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.