### PR TITLE
Update base VM template (packer-debian-12.11.0-20250604234739)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-12",
       "builder_type": "proxmox-iso",
-      "build_time": 1749052970,
+      "build_time": 1749081525,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "14fa1ef7-b757-0fd8-7868-5dd434630957",
+      "packer_run_uuid": "81d17dbb-cef2-2465-5dc8-a0365bf889ae",
       "custom_data": {
-        "git_tag": "v12.11.0.20250604155202",
-        "vm_name": "packer-debian-12.11.0-20250604155202"
+        "git_tag": "v12.11.0.20250604234739",
+        "vm_name": "packer-debian-12.11.0-20250604234739"
       }
     }
   ],
-  "last_run_uuid": "14fa1ef7-b757-0fd8-7868-5dd434630957"
+  "last_run_uuid": "81d17dbb-cef2-2465-5dc8-a0365bf889ae"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.