### PR TITLE
Prevent the format workflow from triggering another run

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Format Terraform files
+      - name: Run Terraform fmt command
         id: fmt
         run: |
           CHANGED_FILES=$(terraform fmt -recursive .)
@@ -35,5 +35,5 @@ jobs:
           git config user.email "actions@github.com"
 
           git add .
-          git commit -m "style: terraform fmt"
+          git commit -m "[skip ci] style: terraform fmt"
           git push


### PR DESCRIPTION
Check what happens if the plan has "no changes", but before merge I delete the VMs in Proxmox, thus creating a drift.