### PR TITLE
Update base VM template (packer-debian-13.0.0-20250810214616)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754854692,
+      "build_time": 1754862722,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "a279d31e-b1b3-a5b8-4959-75c707fb6c01",
+      "packer_run_uuid": "82698a2a-9802-5a39-8937-cec9d79e1f4f",
       "custom_data": {
-        "git_tag": "v13.0.0.20250810193222",
-        "vm_name": "packer-debian-13.0.0-20250810193222"
+        "git_tag": "v13.0.0.20250810214616",
+        "vm_name": "packer-debian-13.0.0-20250810214616"
       }
     }
   ],
-  "last_run_uuid": "a279d31e-b1b3-a5b8-4959-75c707fb6c01"
+  "last_run_uuid": "82698a2a-9802-5a39-8937-cec9d79e1f4f"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.