### PR TITLE
Update base VM template (packer-debian-13.0.0-20250810215617)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754862722,
+      "build_time": 1754863349,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "82698a2a-9802-5a39-8937-cec9d79e1f4f",
+      "packer_run_uuid": "6eec87ff-df94-3cac-302f-c5aeaf328dd7",
       "custom_data": {
-        "git_tag": "v13.0.0.20250810214616",
-        "vm_name": "packer-debian-13.0.0-20250810214616"
+        "git_tag": "v13.0.0.20250810215617",
+        "vm_name": "packer-debian-13.0.0-20250810215617"
       }
     }
   ],
-  "last_run_uuid": "82698a2a-9802-5a39-8937-cec9d79e1f4f"
+  "last_run_uuid": "6eec87ff-df94-3cac-302f-c5aeaf328dd7"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.