### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812080038)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754913011,
+      "build_time": 1754985975,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "17c6294b-54e1-ed95-2974-eaf7932cb436",
+      "packer_run_uuid": "02b8b429-e9df-5e2b-db1c-622626ce7c16",
       "custom_data": {
-        "git_tag": "v13.0.0.20250811114440",
-        "vm_name": "packer-debian-13.0.0-20250811114440"
+        "git_tag": "v13.0.0.20250812080038",
+        "vm_name": "packer-debian-13.0.0-20250812080038"
       }
     }
   ],
-  "last_run_uuid": "17c6294b-54e1-ed95-2974-eaf7932cb436"
+  "last_run_uuid": "02b8b429-e9df-5e2b-db1c-622626ce7c16"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.