### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812090539)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754985975,
+      "build_time": 1754989875,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "02b8b429-e9df-5e2b-db1c-622626ce7c16",
+      "packer_run_uuid": "deb0e7d9-06b0-e593-5dd8-50ecaca66c3c",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812080038",
-        "vm_name": "packer-debian-13.0.0-20250812080038"
+        "git_tag": "v13.0.0.20250812090539",
+        "vm_name": "packer-debian-13.0.0-20250812090539"
       }
     }
   ],
-  "last_run_uuid": "02b8b429-e9df-5e2b-db1c-622626ce7c16"
+  "last_run_uuid": "deb0e7d9-06b0-e593-5dd8-50ecaca66c3c"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.