### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812092726)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754989875,
+      "build_time": 1754991185,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "deb0e7d9-06b0-e593-5dd8-50ecaca66c3c",
+      "packer_run_uuid": "b2fd1251-c8cc-130b-3d5d-0b629a4d5c48",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812090539",
-        "vm_name": "packer-debian-13.0.0-20250812090539"
+        "git_tag": "v13.0.0.20250812092726",
+        "vm_name": "packer-debian-13.0.0-20250812092726"
       }
     }
   ],
-  "last_run_uuid": "deb0e7d9-06b0-e593-5dd8-50ecaca66c3c"
+  "last_run_uuid": "b2fd1251-c8cc-130b-3d5d-0b629a4d5c48"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.