### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812100033)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754991185,
+      "build_time": 1754993196,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "b2fd1251-c8cc-130b-3d5d-0b629a4d5c48",
+      "packer_run_uuid": "95d33c73-c3db-b989-f819-d82fe4587d3d",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812092726",
-        "vm_name": "packer-debian-13.0.0-20250812092726"
+        "git_tag": "v13.0.0.20250812100033",
+        "vm_name": "packer-debian-13.0.0-20250812100033"
       }
     }
   ],
-  "last_run_uuid": "b2fd1251-c8cc-130b-3d5d-0b629a4d5c48"
+  "last_run_uuid": "95d33c73-c3db-b989-f819-d82fe4587d3d"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.