### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812112641)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754995736,
+      "build_time": 1754998365,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "ce7ffd12-6610-c310-1854-8d6978175ef8",
+      "packer_run_uuid": "a036b97b-0b61-29d2-63fe-87ad79a8a931",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812104237",
-        "vm_name": "packer-debian-13.0.0-20250812104237"
+        "git_tag": "v13.0.0.20250812112641",
+        "vm_name": "packer-debian-13.0.0-20250812112641"
       }
     }
   ],
-  "last_run_uuid": "ce7ffd12-6610-c310-1854-8d6978175ef8"
+  "last_run_uuid": "a036b97b-0b61-29d2-63fe-87ad79a8a931"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.