### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812120500)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1754998365,
+      "build_time": 1755000669,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "a036b97b-0b61-29d2-63fe-87ad79a8a931",
+      "packer_run_uuid": "cbfa9756-2795-7be1-310f-39d30c76e8bc",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812112641",
-        "vm_name": "packer-debian-13.0.0-20250812112641"
+        "git_tag": "v13.0.0.20250812120500",
+        "vm_name": "packer-debian-13.0.0-20250812120500"
       }
     }
   ],
-  "last_run_uuid": "a036b97b-0b61-29d2-63fe-87ad79a8a931"
+  "last_run_uuid": "cbfa9756-2795-7be1-310f-39d30c76e8bc"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.