### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812134026)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755005485,
+      "build_time": 1755006366,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "89c8c8f2-c7b6-3506-be86-7665cfcc7c91",
+      "packer_run_uuid": "d21bee09-a6c3-561f-d31d-7edc7e03f61d",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812132548",
-        "vm_name": "packer-debian-13.0.0-20250812132548"
+        "git_tag": "v13.0.0.20250812134026",
+        "vm_name": "packer-debian-13.0.0-20250812134026"
       }
     }
   ],
-  "last_run_uuid": "89c8c8f2-c7b6-3506-be86-7665cfcc7c91"
+  "last_run_uuid": "d21bee09-a6c3-561f-d31d-7edc7e03f61d"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.