### PR TITLE
Update base VM template (packer-debian-13.0.0-20250812140623)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755006366,
+      "build_time": 1755007921,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "d21bee09-a6c3-561f-d31d-7edc7e03f61d",
+      "packer_run_uuid": "403f83c8-9f07-8b7e-a1fb-f8db9e5247e1",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812134026",
-        "vm_name": "packer-debian-13.0.0-20250812134026"
+        "git_tag": "v13.0.0.20250812140623",
+        "vm_name": "packer-debian-13.0.0-20250812140623"
       }
     }
   ],
-  "last_run_uuid": "d21bee09-a6c3-561f-d31d-7edc7e03f61d"
+  "last_run_uuid": "403f83c8-9f07-8b7e-a1fb-f8db9e5247e1"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.