### PR TITLE
Update base VM template (packer-debian-13.0.0-20250813080527)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755007921,
+      "build_time": 1755072691,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "403f83c8-9f07-8b7e-a1fb-f8db9e5247e1",
+      "packer_run_uuid": "88b1403e-dafe-8e7a-7e02-e4045e0352bb",
       "custom_data": {
-        "git_tag": "v13.0.0.20250812140623",
-        "vm_name": "packer-debian-13.0.0-20250812140623"
+        "git_tag": "v13.0.0.20250813080527",
+        "vm_name": "packer-debian-13.0.0-20250813080527"
       }
     }
   ],
-  "last_run_uuid": "403f83c8-9f07-8b7e-a1fb-f8db9e5247e1"
+  "last_run_uuid": "88b1403e-dafe-8e7a-7e02-e4045e0352bb"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.