### PR TITLE
Update base VM template (packer-debian-13.0.0-20250813082633)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755072691,
+      "build_time": 1755073957,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "88b1403e-dafe-8e7a-7e02-e4045e0352bb",
+      "packer_run_uuid": "e2a50940-3d1e-27b5-c37e-e6a2c426b253",
       "custom_data": {
-        "git_tag": "v13.0.0.20250813080527",
-        "vm_name": "packer-debian-13.0.0-20250813080527"
+        "git_tag": "v13.0.0.20250813082633",
+        "vm_name": "packer-debian-13.0.0-20250813082633"
       }
     }
   ],
-  "last_run_uuid": "88b1403e-dafe-8e7a-7e02-e4045e0352bb"
+  "last_run_uuid": "e2a50940-3d1e-27b5-c37e-e6a2c426b253"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.