### PR TITLE
Update base VM template (packer-debian-13.0.0-20250813083927)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755073957,
+      "build_time": 1755074738,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "e2a50940-3d1e-27b5-c37e-e6a2c426b253",
+      "packer_run_uuid": "da93448d-a189-e385-ec02-14915ea70349",
       "custom_data": {
-        "git_tag": "v13.0.0.20250813082633",
-        "vm_name": "packer-debian-13.0.0-20250813082633"
+        "git_tag": "v13.0.0.20250813083927",
+        "vm_name": "packer-debian-13.0.0-20250813083927"
       }
     }
   ],
-  "last_run_uuid": "e2a50940-3d1e-27b5-c37e-e6a2c426b253"
+  "last_run_uuid": "da93448d-a189-e385-ec02-14915ea70349"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.