### PR TITLE
Update base VM template (packer-debian-13.0.0-20250813085336)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755074738,
+      "build_time": 1755075583,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "da93448d-a189-e385-ec02-14915ea70349",
+      "packer_run_uuid": "d72af5b0-38e2-966a-1214-fa2145de314a",
       "custom_data": {
-        "git_tag": "v13.0.0.20250813083927",
-        "vm_name": "packer-debian-13.0.0-20250813083927"
+        "git_tag": "v13.0.0.20250813085336",
+        "vm_name": "packer-debian-13.0.0-20250813085336"
       }
     }
   ],
-  "last_run_uuid": "da93448d-a189-e385-ec02-14915ea70349"
+  "last_run_uuid": "d72af5b0-38e2-966a-1214-fa2145de314a"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.