### PR TITLE
Update base VM template (packer-debian-13.0.0-20250813090015)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1755074738,
+      "build_time": 1755075992,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "da93448d-a189-e385-ec02-14915ea70349",
+      "packer_run_uuid": "be9e69de-92d8-eb24-d2e1-a69be791e504",
       "custom_data": {
-        "git_tag": "v13.0.0.20250813083927",
-        "vm_name": "packer-debian-13.0.0-20250813083927"
+        "git_tag": "v13.0.0.20250813090015",
+        "vm_name": "packer-debian-13.0.0-20250813090015"
       }
     }
   ],
-  "last_run_uuid": "da93448d-a189-e385-ec02-14915ea70349"
+  "last_run_uuid": "be9e69de-92d8-eb24-d2e1-a69be791e504"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.