### PR TITLE
Update base VM template (packer-debian-13.1.0-20251109173409)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1758454899,
+      "build_time": 1762710081,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "a67a2fc7-ba0c-12f4-a680-38729a36b783",
+      "packer_run_uuid": "2bb44cfc-d31d-f9ad-3596-c640ced69fc6",
       "custom_data": {
-        "git_tag": "v13.1.0.20250921113516",
-        "vm_name": "packer-debian-13.1.0-20250921113516"
+        "git_tag": "v13.1.0.20251109173409",
+        "vm_name": "packer-debian-13.1.0-20251109173409"
       }
     }
   ],
-  "last_run_uuid": "a67a2fc7-ba0c-12f4-a680-38729a36b783"
+  "last_run_uuid": "2bb44cfc-d31d-f9ad-3596-c640ced69fc6"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.