### PR TITLE
Update base VM template (packer-debian-13.2.0-20251202165740)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1764669533,
+      "build_time": 1764695034,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "3b9f287a-2e69-5703-2047-65750a5a727a",
+      "packer_run_uuid": "438fbb22-f287-0fbc-e690-b6805eca5e25",
       "custom_data": {
-        "git_tag": "v13.2.0.20251202095245",
-        "vm_name": "packer-debian-13.2.0-20251202095245"
+        "git_tag": "v13.2.0.20251202165740",
+        "vm_name": "packer-debian-13.2.0-20251202165740"
       }
     }
   ],
-  "last_run_uuid": "3b9f287a-2e69-5703-2047-65750a5a727a"
+  "last_run_uuid": "438fbb22-f287-0fbc-e690-b6805eca5e25"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.