### PR TITLE
Update base VM template (packer-debian-13.2.0-20251204161416)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1764857861,
+      "build_time": 1764865234,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "ebc8164a-d254-e778-7dbc-d54c7b450a6b",
+      "packer_run_uuid": "96883a43-4ecf-9d55-98ae-078ef8ee3c2a",
       "custom_data": {
-        "git_tag": "v13.2.0.20251204141123",
-        "vm_name": "packer-debian-13.2.0-20251204141123"
+        "git_tag": "v13.2.0.20251204161416",
+        "vm_name": "packer-debian-13.2.0-20251204161416"
       }
     }
   ],
-  "last_run_uuid": "ebc8164a-d254-e778-7dbc-d54c7b450a6b"
+  "last_run_uuid": "96883a43-4ecf-9d55-98ae-078ef8ee3c2a"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.