### PR TITLE
Update base VM template (packer-debian-13.2.0-20251224170634)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1765315674,
+      "build_time": 1766596278,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "bccadb64-a523-1dfc-10df-53f759730d35",
+      "packer_run_uuid": "825c4885-e1af-7c95-d739-e77d70304395",
       "custom_data": {
-        "git_tag": "v13.2.0.20251209212133",
-        "vm_name": "packer-debian-13.2.0-20251209212133"
+        "git_tag": "v13.2.0.20251224170634",
+        "vm_name": "packer-debian-13.2.0-20251224170634"
       }
     }
   ],
-  "last_run_uuid": "bccadb64-a523-1dfc-10df-53f759730d35"
+  "last_run_uuid": "825c4885-e1af-7c95-d739-e77d70304395"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.