### PR TITLE
Update base VM template (packer-debian-13.2.0-20251229212450)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1767014662,
+      "build_time": 1767044116,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "4b1c820b-1c1f-e743-1a3d-3948d9ccbada",
+      "packer_run_uuid": "2e5da652-bf45-718b-8378-1034cb73cab5",
       "custom_data": {
-        "git_tag": "v13.2.0.20251229131928",
-        "vm_name": "packer-debian-13.2.0-20251229131928"
+        "git_tag": "v13.2.0.20251229212450",
+        "vm_name": "packer-debian-13.2.0-20251229212450"
       }
     }
   ],
-  "last_run_uuid": "4b1c820b-1c1f-e743-1a3d-3948d9ccbada"
+  "last_run_uuid": "2e5da652-bf45-718b-8378-1034cb73cab5"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.