### PR TITLE
Update base VM template (packer-debian-13.3.0-20260205104558)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,15 +3,15 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1770208082,
+      "build_time": 1770289793,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "6ec6ec60-2ce7-a52a-0b8f-c7e628cc48e5",
+      "packer_run_uuid": "f4db2a8c-4587-c88a-be80-1ec7208adc0b",
       "custom_data": {
-        "git_tag": "v13.3.0.20260204115612",
-        "vm_name": "packer-debian-13.3.0-20260204115612"
+        "git_tag": "v13.3.0.20260205104558",
+        "vm_name": "packer-debian-13.3.0-20260205104558"
       }
     }
   ],
-  "last_run_uuid": "6ec6ec60-2ce7-a52a-0b8f-c7e628cc48e5"
+  "last_run_uuid": "f4db2a8c-4587-c88a-be80-1ec7208adc0b"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.