### PR TITLE
Update base VM template (packer-debian-13.3.0-20260208000132)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1770296351,
+      "build_time": 1770510685,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "7bf1c9f1-7f4b-12fb-249a-ec426904fbf4",
+      "packer_run_uuid": "46678ae2-333c-67a9-a891-8051561a1b76",
       "custom_data": {
-        "git_tag": "v13.3.0.20260205123421",
+        "git_tag": "v13.3.0.20260208000132",
         "i915_sriov_version": "2026.02.04",
-        "vm_name": "packer-debian-13.3.0-20260205123421"
+        "vm_name": "packer-debian-13.3.0-20260208000132"
       }
     }
   ],
-  "last_run_uuid": "7bf1c9f1-7f4b-12fb-249a-ec426904fbf4"
+  "last_run_uuid": "46678ae2-333c-67a9-a891-8051561a1b76"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.