### PR TITLE
Update base VM template (packer-debian-13.3.0-20260209142753)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1770510685,
+      "build_time": 1770649077,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "46678ae2-333c-67a9-a891-8051561a1b76",
+      "packer_run_uuid": "b35df0ab-6f50-7788-b334-81de8955dbac",
       "custom_data": {
-        "git_tag": "v13.3.0.20260208000132",
-        "i915_sriov_version": "2026.02.04",
-        "vm_name": "packer-debian-13.3.0-20260208000132"
+        "git_tag": "v13.3.0.20260209142753",
+        "i915_sriov_version": "2026.02.09",
+        "vm_name": "packer-debian-13.3.0-20260209142753"
       }
     }
   ],
-  "last_run_uuid": "46678ae2-333c-67a9-a891-8051561a1b76"
+  "last_run_uuid": "b35df0ab-6f50-7788-b334-81de8955dbac"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.