### PR TITLE
Update base VM template (packer-debian-13.3.0-20260210142114)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1770649077,
+      "build_time": 1770735190,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "b35df0ab-6f50-7788-b334-81de8955dbac",
+      "packer_run_uuid": "9dac8523-6658-7704-9242-1d7368e14004",
       "custom_data": {
-        "git_tag": "v13.3.0.20260209142753",
+        "git_tag": "v13.3.0.20260210142114",
         "i915_sriov_version": "2026.02.09",
-        "vm_name": "packer-debian-13.3.0-20260209142753"
+        "vm_name": "packer-debian-13.3.0-20260210142114"
       }
     }
   ],
-  "last_run_uuid": "b35df0ab-6f50-7788-b334-81de8955dbac"
+  "last_run_uuid": "9dac8523-6658-7704-9242-1d7368e14004"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.