### PR TITLE
Update base VM template (packer-debian-13.3.0-20260226231317)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1770735190,
+      "build_time": 1772148317,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "9dac8523-6658-7704-9242-1d7368e14004",
+      "packer_run_uuid": "0b88f4d0-219f-efb7-ceb0-04299fb5fd92",
       "custom_data": {
-        "git_tag": "v13.3.0.20260210142114",
+        "git_tag": "v13.3.0.20260226231317",
         "i915_sriov_version": "2026.02.09",
-        "vm_name": "packer-debian-13.3.0-20260210142114"
+        "vm_name": "packer-debian-13.3.0-20260226231317"
       }
     }
   ],
-  "last_run_uuid": "9dac8523-6658-7704-9242-1d7368e14004"
+  "last_run_uuid": "0b88f4d0-219f-efb7-ceb0-04299fb5fd92"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.