### PR TITLE
Update base VM template (packer-debian-13.3.0-20260308100442)

### DIFF
--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1772148317,
+      "build_time": 1772965007,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "0b88f4d0-219f-efb7-ceb0-04299fb5fd92",
+      "packer_run_uuid": "3301d3a1-c71e-b972-a0dd-1fe32242e979",
       "custom_data": {
-        "git_tag": "v13.3.0.20260226231317",
-        "i915_sriov_version": "2026.02.09",
-        "vm_name": "packer-debian-13.3.0-20260226231317"
+        "git_tag": "v13.3.0.20260308100442",
+        "i915_sriov_version": "2026.03.05",
+        "vm_name": "packer-debian-13.3.0-20260308100442"
       }
     }
   ],
-  "last_run_uuid": "0b88f4d0-219f-efb7-ceb0-04299fb5fd92"
+  "last_run_uuid": "3301d3a1-c71e-b972-a0dd-1fe32242e979"
 }


### PR DESCRIPTION
This PR updates the Packer manifest file with the latest build information.