### PR TITLE
fix: enable PCIe mode for SR-IOV VF passthrough

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "worker_nodes" {
 
   pci_devices = [{
     host   = "k3s-worker-gpus"
-    pcie   = false
+    pcie   = true
     rombar = false
   }]
 

--- a/packer-manifest.json
+++ b/packer-manifest.json
@@ -3,16 +3,16 @@
     {
       "name": "debian-13",
       "builder_type": "proxmox-iso",
-      "build_time": 1777894763,
+      "build_time": 1777900769,
       "files": null,
       "artifact_id": "900",
-      "packer_run_uuid": "d5c2dc7b-2d08-f5e7-0a65-bc0b2903945e",
+      "packer_run_uuid": "d9be055d-3521-2386-72e5-5cfad8bd6d59",
       "custom_data": {
-        "git_tag": "v13.4.0.20260504113340",
+        "git_tag": "v13.4.0.20260504131231",
         "i915_sriov_version": "2026.05.03",
-        "vm_name": "packer-debian-13.4.0-20260504113340"
+        "vm_name": "packer-debian-13.4.0-20260504131231"
       }
     }
   ],
-  "last_run_uuid": "d5c2dc7b-2d08-f5e7-0a65-bc0b2903945e"
+  "last_run_uuid": "d9be055d-3521-2386-72e5-5cfad8bd6d59"
 }


### PR DESCRIPTION
## Problem

After upgrading `i915-sriov-dkms` to `2026.05.03` (via Packer/Ansible PRs), all GPU-dependent pods fail to schedule:

```
0/3 nodes are available: 3 Insufficient gpu.intel.com/i915
```

Inside the VMs, the i915 driver fails to probe the VF:
```
i915 0000:06:10.0: [drm] *ERROR* Device is non-operational; MMIO access returns 0xFFFFFFFF!
i915 0000:06:10.0: [drm] *ERROR* Device initialization failed (-5)
```

Only `/dev/dri/card0` (bochs VGA) exists — no `renderD128`, so the Intel GPU device plugin advertises zero GPUs.

## Root Cause

SR-IOV VFs are passed through with `pcie = false` (legacy PCI bus emulation). The old driver tolerated this, but the new version requires proper PCIe topology for MMIO BAR access.

## Fix

Set `pcie = true` for the worker node PCI passthrough config.

## Affected Services

- Jellyfin
- Immich (server + machine-learning)
- ConvertX