### PR TITLE
revert: pcie=true change (not the root cause)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "worker_nodes" {
 
   pci_devices = [{
     host   = "k3s-worker-gpus"
-    pcie   = true
+    pcie   = false
     rombar = false
   }]
 


### PR DESCRIPTION
Reverts the `pcie = true` change from #179.

The root cause was the new SR-IOV driver version (not the PCIe flag). Reverting to `pcie = false` which was working with the previous driver.