### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# See https://pre-commit.com for usage. Mirrors the checks run in CI
+# (format.yml + validate-and-plan.yml) so issues are caught before pushing.
+# Hook versions are kept up to date by Renovate (`:enablePreCommit`).
+minimum_pre_commit_version: '3.0.0'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-added-large-files
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.4
+    hooks:
+      - id: prettier
+        files: \.(ya?ml|json)$
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.108.0
+    hooks:
+      - id: terraform_fmt


### PR DESCRIPTION
## Summary
Adds a `.pre-commit-config.yaml` mirroring the CI checks so issues are caught before pushing.

## Changes
- `terraform_fmt` (antonbabenko/pre-commit-terraform)
- `prettier` (yaml/json)
- generic hygiene: `check-merge-conflict`, `check-json`, `check-added-large-files`

Hook versions are Renovate-managed via `:enablePreCommit`.

## Verification
`pre-commit run --all-files` → all hooks **Passed**.