### PR TITLE
fix(vm): pin vm_state to stop perpetual drift (#196)

### DIFF
--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -25,7 +25,7 @@ resource "proxmox_vm_qemu" "vm" {
 
   memory = var.memory
 
-  vm_state = "running"
+  power_state = "running"
 
   os_type    = var.os_type
   ciuser     = var.ciuser

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -25,6 +25,8 @@ resource "proxmox_vm_qemu" "vm" {
 
   memory = var.memory
 
+  vm_state = "running"
+
   os_type    = var.os_type
   ciuser     = var.ciuser
   cipassword = var.cipassword


### PR DESCRIPTION
## Problem

Scheduled drift checks flag the same in-place update on all three k3s nodes every run (#196):

```
- vm_state = "running" -> null
~ default_ipv4_address / ssh_host / ssh_port -> (known after apply)
```

## Root cause

Single driver: telmate/proxmox `3.0.2-rc08` plans `vm_state "running" -> null` on every refresh because the module never sets it. The `default_ipv4_address`/`ssh_host`/`ssh_port` "known after apply" lines are downstream of that forced update — they only recompute because the resource is being changed.

## Fix

Pin `vm_state = "running"` in the shared `modules/vm` module (all three nodes route through it). Terraform now converges instead of re-planning each check.

**Note:** with `vm_state` pinned, powering a node off for maintenance will make Terraform plan to start it back up on the next apply.

Fixes #196